### PR TITLE
Wrong disctionary at the notify method (Tryton Bug Tracker Issue7807 )

### DIFF
--- a/trytond/bus.py
+++ b/trytond/bus.py
@@ -245,9 +245,9 @@ def notify(title, body=None, priority=1, user=None, client=None):
     else:
         channel = 'client:%s' % client
 
-    return Bus.publish({
+    return Bus.publish(channel, {
             'type': 'notification',
             'title': title,
             'body': body,
             'priority': priority,
-            }, channel)
+            })


### PR DESCRIPTION
Traceback (most recent call last):
  File "\site-packages\trytond\wsgi.py", line 73, in dispatch_request
    return endpoint(request, **request.view_args)
  File "\site-packages\trytond\protocols\dispatcher.py", line 46, in rpc
    request, database_name, *request.rpc_params)
  File "\site-packages\wrapt\wrappers.py", line 523, in __call__
    args, kwargs)
  File "\site-packages\trytond\wsgi.py", line 44, in auth_required
    return wrapped(*args, **kwargs)
  File "\site-packages\trytond\protocols\wrappers.py", line 122, in wrapper
    return func(request, pool, *args, **kwargs)
  File "\site-packages\trytond\protocols\dispatcher.py", line 176, in _dispatch
    result = rpc.result(meth(*c_args, **c_kwargs))
  File "\site-packages\trytond\modules\tri_barcode\store.py", line 96, in print_xd_toid
    notify('Print TO ID XD', 'Successful send to Printer',  priority=2)
  File "\site-packages\trytond\bus.py", line 257, in notify
    }, channel)
  File "\site-packages\trytond\bus.py", line 198, in publish
    message['message_id'] = str(uuid.uuid4())
TypeError: 'str' object does not support item assignment